### PR TITLE
Remove atom from roll-all-18s and flip cond branches

### DIFF
--- a/src/stats_generator/main.clj
+++ b/src/stats_generator/main.clj
@@ -47,27 +47,27 @@
 
 (defn now [] (new java.util.Date))
 
-(defn roll-all-18s [roll-type]
- (let [counter (atom 0)]
-   (println "STARTED AT:" (now))
-    (loop [current-roll []]
-      (swap! counter inc)
-      (cond
-        (= 100000000 @counter)
-        (do
-          (println "Gave up after ONE HUNDRED MILLION sets...")
-          (println "ENDED AT:" (now)))
+(defn roll-all-18s []
+  (println "STARTED AT:" (now))
+  (loop [counter 1
+         current-roll (roll-stats)]
+    (cond
+      (= [18 18 18 18 18 18] current-roll)
+      (do
+        (println "All 18s took" counter "attempt(s).")
+        (println "ENDED AT:" (now)))
 
-        (= [18 18 18 18 18 18] current-roll)
-        (do
-          (println "All 18s took" @counter "attempt(s).")
-          (println "ENDED AT:" (now)))
+      (= 100000000 counter)
+      (do
+        (println "Gave up after ONE HUNDRED MILLION sets...")
+        (println "ENDED AT:" (now)))
 
-        :default
-        (do
-          (when (<= 5 (count (filter #(= 18 %) current-roll)))
-            (println "close call!" current-roll))
-          (recur (roll-stats roll-type)))))))
+      :default
+      (do
+        (when (<= 5 (count (filter #(= 18 %) current-roll)))
+          (println "close call!" current-roll))
+        (recur (inc counter)
+               (roll-stats))))))
 
 (defn -main
   [& args]


### PR DESCRIPTION
Atoms are ugly and there isn't a need for one since there is already a `loop` construct to hold state for us.

I also flipped the first two branches of the conditional. This should allow the one hundred millionth roll to hit all 18s. Before, this roll could have hit all 18s but it quit early.